### PR TITLE
fix: change invalid dial_code for CAYMAN ISLANDS (KY)

### DIFF
--- a/src/data.ts
+++ b/src/data.ts
@@ -386,7 +386,7 @@ const countries: CountryInterface[] = [
   },
   {
     name: 'Cayman Islands',
-    dial_code: '+345',
+    dial_code: '+1345',
     code: 'KY',
     flag: '🇰🇾',
     part_of: ['GB'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected international dialing code for Cayman Islands from +345 to +1345, ensuring accurate phone number formatting and validation across forms, contact flows, and communications. Users selecting Cayman Islands will now see the correct country code prefilled, preventing failed verifications, messages, or calls and improving success rates for phone-based actions globally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->