### PR TITLE
fix: ensure consistent module format between dev and production builds

### DIFF
--- a/webpack.cdn.config.js
+++ b/webpack.cdn.config.js
@@ -12,6 +12,7 @@ module.exports = {
   output: {
     filename: '[name].js',
     path: path.resolve(__dirname, 'dist'),
+    libraryTarget: 'commonjs'
   },
   optimization: {
     minimize: true,


### PR DESCRIPTION
## Problem

The webpack configurations for development and production environments have inconsistent `libraryTarget` settings, causing module format differences:

- **Development** (webpack.cdn.config.js): No `libraryTarget` specified → exports module directly
- **Production** (webpack.config.js): `libraryTarget: 'commonjs'` → wraps export in `{ default: ... }`

This inconsistency forces consumers to use fallback logic like:
```javascript
export const CountryList = (CountryListInstance as any).default || CountryListInstance
```

## Solution

Add `libraryTarget: 'commonjs'` to `webpack.cdn.config.js` to match the production configuration, ensuring consistent module exports across environments.

## Changes

- Added `libraryTarget: 'commonjs'` to webpack.cdn.config.js (line 15)

## Testing

This change ensures that both development and production builds export modules in the same format, eliminating the need for environment-specific fallback logic in consuming applications.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to output bundles in CommonJS format, improving compatibility with CommonJS environments and certain bundlers/CDNs.
  * Enhances interoperability and simplifies integration in server-side and legacy toolchains.
  * No changes to app functionality or user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->